### PR TITLE
Company CRUD

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,3 +62,7 @@ dependencyManagement {
 tasks.named('test') {
 	useJUnitPlatform()
 }
+
+springBoot {
+    mainClass = 'com.tunaforce.company.CompanyApplication'
+}

--- a/build.gradle
+++ b/build.gradle
@@ -29,16 +29,28 @@ ext {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
-	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'org.postgresql:postgresql'
+	// ===== Core: Spring Boot Starters =====
+	implementation 'org.springframework.boot:spring-boot-starter-web'          // 웹 MVC, JSON, 내장 톰캣
+	// implementation 'org.springframework.boot:spring-boot-starter-actuator'   // 헬스체크/메트릭 (필요 시 주석 해제)
+
+	// ===== Persistence / Data Access =====
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'     // JPA/Hibernate
+	runtimeOnly   'org.postgresql:postgresql'                                   // PostgreSQL JDBC 드라이버
+
+	// ===== Validation =====
+	implementation 'org.springframework.boot:spring-boot-starter-validation'    // Bean Validation
+
+	// ===== Cloud / Service Discovery / HTTP Clients =====
+	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client' // 유레카 클라이언트
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'              // OpenFeign HTTP 클라이언트
+
+	// ===== Build-time Tools =====
+	compileOnly         'org.projectlombok:lombok'                              // Lombok(컴파일 시)
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// ===== Test =====
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'      // JUnit/AssertJ/Mockito 등
+	testRuntimeOnly   'org.junit.platform:junit-platform-launcher'              // 테스트 런처(런타임)
 }
 
 dependencyManagement {

--- a/src/main/java/com/tunaforce/company/CompanyApplication.java
+++ b/src/main/java/com/tunaforce/company/CompanyApplication.java
@@ -3,8 +3,10 @@ package com.tunaforce.company;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @EnableJpaAuditing // createdAt, updatedAt 자동 세팅
+@EnableFeignClients(basePackages = "com.tunaforce.company")
 @SpringBootApplication
 public class CompanyApplication {
 

--- a/src/main/java/com/tunaforce/company/client/HubClient.java
+++ b/src/main/java/com/tunaforce/company/client/HubClient.java
@@ -1,0 +1,16 @@
+package com.tunaforce.company.client;
+
+import com.tunaforce.company.client.dto.HubGetResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.UUID;
+
+// name: Eureka 서비스명 (properties로 override 가능), url: 로컬 테스트 등 직접 URL 지정시 사용
+@FeignClient(name = "${clients.hub.name:hub}", url = "${clients.hub.url:}")
+public interface HubClient {
+
+    @GetMapping("/hubs/{hubId}")
+    HubGetResponse getHub(@PathVariable("hubId") UUID hubId);
+}

--- a/src/main/java/com/tunaforce/company/client/HubClient.java
+++ b/src/main/java/com/tunaforce/company/client/HubClient.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import java.util.UUID;
 
 // name: Eureka 서비스명 (properties로 override 가능), url: 로컬 테스트 등 직접 URL 지정시 사용
-@FeignClient(name = "${clients.hub.name:hub}", url = "${clients.hub.url:}")
+@FeignClient(name = "${clients.hub.name:hub}")
 public interface HubClient {
 
     @GetMapping("/hubs/{hubId}")

--- a/src/main/java/com/tunaforce/company/client/HubClient.java
+++ b/src/main/java/com/tunaforce/company/client/HubClient.java
@@ -13,4 +13,8 @@ public interface HubClient {
 
     @GetMapping("/hubs/{hubId}")
     HubGetResponse getHub(@PathVariable("hubId") UUID hubId);
+
+    // 허브 관리자 → 허브 조회 API 연동
+    @GetMapping("/hubs/admins/{hubAdminId}")
+    com.tunaforce.company.client.dto.HubByAdminResponse getHubByAdmin(@PathVariable("hubAdminId") UUID hubAdminId);
 }

--- a/src/main/java/com/tunaforce/company/client/dto/HubByAdminResponse.java
+++ b/src/main/java/com/tunaforce/company/client/dto/HubByAdminResponse.java
@@ -1,0 +1,5 @@
+package com.tunaforce.company.client.dto;
+
+import java.util.UUID;
+
+public record HubByAdminResponse(UUID hubId, String hubName) {}

--- a/src/main/java/com/tunaforce/company/client/dto/HubGetResponse.java
+++ b/src/main/java/com/tunaforce/company/client/dto/HubGetResponse.java
@@ -1,0 +1,11 @@
+package com.tunaforce.company.client.dto;
+
+import java.util.UUID;
+
+public record HubGetResponse(
+        UUID hubId,
+        String hubName,
+        String hubAddress,
+        Double hubLatitude,
+        Double hubLongitude
+) {}

--- a/src/main/java/com/tunaforce/company/controller/CompanyController.java
+++ b/src/main/java/com/tunaforce/company/controller/CompanyController.java
@@ -1,5 +1,7 @@
 package com.tunaforce.company.controller;
 
+import com.tunaforce.company.dto.request.CompanySaveRequestDto;
+import com.tunaforce.company.dto.response.CompanyListResponseDto;
 import com.tunaforce.company.dto.response.CompanyResponseDto;
 import com.tunaforce.company.service.CompanyService;
 import feign.Response;
@@ -15,13 +17,11 @@ public class CompanyController {
 
     private final CompanyService companyService;
 
-    // TODO: 업체 프로필
     @GetMapping("/{companyId}")
     public ResponseEntity<CompanyResponseDto> getCompanyInfo(@PathVariable("companyId") String companyId) {
         return ResponseEntity.ok(companyService.getCompanyInfo(companyId));
     }
 
-    // TODO: 업체 검색
     @GetMapping
     public ResponseEntity<CompanyListResponseDto> searchCompany(
             @RequestParam(value = "name", required = false) String name,
@@ -29,7 +29,6 @@ public class CompanyController {
         return ResponseEntity.ok(companyService.searchCompany(name, hubId));
     }
 
-    // TODO: 업체 등록
     @PostMapping
     public ResponseEntity<Void> createCompany(@Valid @RequestBody CompanySaveRequestDto companySaveRequestDto) {
         companyService.createCompany(companySaveRequestDto);

--- a/src/main/java/com/tunaforce/company/controller/CompanyController.java
+++ b/src/main/java/com/tunaforce/company/controller/CompanyController.java
@@ -1,0 +1,52 @@
+package com.tunaforce.company.controller;
+
+import com.tunaforce.company.dto.response.CompanyResponseDto;
+import com.tunaforce.company.service.CompanyService;
+import feign.Response;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/companies")
+public class CompanyController {
+
+    private final CompanyService companyService;
+
+    // TODO: 업체 프로필
+    @GetMapping("/{companyId}")
+    public ResponseEntity<CompanyResponseDto> getCompanyInfo(@PathVariable("companyId") String companyId) {
+        return ResponseEntity.ok(companyService.getCompanyInfo(companyId));
+    }
+
+    // TODO: 업체 검색
+    @GetMapping
+    public ResponseEntity<CompanyListResponseDto> searchCompany(
+            @RequestParam(value = "name", required = false) String name,
+            @RequestParam(value = "hubId", required = false) String hubId) {
+        return ResponseEntity.ok(companyService.searchCompany(name, hubId));
+    }
+
+    // TODO: 업체 등록
+    @PostMapping
+    public ResponseEntity<Void> createCompany(@Valid @RequestBody CompanySaveRequestDto companySaveRequestDto) {
+        companyService.createCompany(companySaveRequestDto);
+        return ResponseEntity.ok().build();
+    }
+
+    //TODO: 업체 정보 수정
+    @PatchMapping("/{companyId}")
+    public ResponseEntity<Void> editCompanyInfo(@PathVariable("companyId") String companyId,
+                                                @Valid @RequestBody CompanySaveRequestDto companySaveRequestDto) {
+        companyService.editCompanyInfo(companyId, companySaveRequestDto);
+        return ResponseEntity.ok().build();
+    }
+    // TODO: 업체 삭제
+    @DeleteMapping("/{companyId}")
+    public ResponseEntity<Void> deleteCompany(@PathVariable("companyId") String companyId) {
+        companyService.deleteCompany(companyId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/tunaforce/company/controller/CompanyController.java
+++ b/src/main/java/com/tunaforce/company/controller/CompanyController.java
@@ -41,7 +41,7 @@ public class CompanyController {
             @PathVariable("companyId") String companyId,
             @Valid @RequestBody CompanySaveRequestDto companySaveRequestDto,
             @RequestHeader(value = "X-User-Id", required = false) UUID userId,
-            @RequestHeader(value = "X-User-Role", required = false) String userRole) {
+            @RequestHeader(value = "X-Roles", required = false) String userRole) {
         companyService.editCompanyInfo(companyId, companySaveRequestDto, userId, userRole);
         return ResponseEntity.ok().build();
     }
@@ -50,7 +50,7 @@ public class CompanyController {
     public ResponseEntity<Void> deleteCompany(
             @PathVariable("companyId") String companyId,
             @RequestHeader(value = "X-User-Id", required = false) UUID userId,
-            @RequestHeader(value = "X-User-Role", required = false) String userRole) {
+            @RequestHeader(value = "X-Roles", required = false) String userRole) {
         companyService.deleteCompany(companyId, userId, userRole);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/tunaforce/company/controller/CompanyController.java
+++ b/src/main/java/com/tunaforce/company/controller/CompanyController.java
@@ -4,7 +4,6 @@ import com.tunaforce.company.dto.request.CompanySaveRequestDto;
 import com.tunaforce.company.dto.response.CompanyListResponseDto;
 import com.tunaforce.company.dto.response.CompanyResponseDto;
 import com.tunaforce.company.service.CompanyService;
-import feign.Response;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -35,17 +34,22 @@ public class CompanyController {
         return ResponseEntity.ok().build();
     }
 
-    //TODO: 업체 정보 수정
     @PatchMapping("/{companyId}")
-    public ResponseEntity<Void> editCompanyInfo(@PathVariable("companyId") String companyId,
-                                                @Valid @RequestBody CompanySaveRequestDto companySaveRequestDto) {
-        companyService.editCompanyInfo(companyId, companySaveRequestDto);
+    public ResponseEntity<Void> editCompanyInfo(
+            @PathVariable("companyId") String companyId,
+            @Valid @RequestBody CompanySaveRequestDto companySaveRequestDto,
+            @RequestHeader(value = "X-User-Id", required = false) String userId,
+            @RequestHeader(value = "X-User-Role", required = false) String userRole) {
+        companyService.editCompanyInfo(companyId, companySaveRequestDto, userId, userRole);
         return ResponseEntity.ok().build();
     }
-    // TODO: 업체 삭제
+
     @DeleteMapping("/{companyId}")
-    public ResponseEntity<Void> deleteCompany(@PathVariable("companyId") String companyId) {
-        companyService.deleteCompany(companyId);
+    public ResponseEntity<Void> deleteCompany(
+            @PathVariable("companyId") String companyId,
+            @RequestHeader(value = "X-User-Id", required = false) String userId,
+            @RequestHeader(value = "X-User-Role", required = false) String userRole) {
+        companyService.deleteCompany(companyId, userId, userRole);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/tunaforce/company/controller/CompanyController.java
+++ b/src/main/java/com/tunaforce/company/controller/CompanyController.java
@@ -27,8 +27,11 @@ public class CompanyController {
     @GetMapping
     public ResponseEntity<CompanyListResponseDto> searchCompany(
             @RequestParam(value = "name", required = false) String name,
-            @RequestParam(value = "hubId", required = false) UUID hubId) {
-        return ResponseEntity.ok(companyService.searchCompany(name, hubId));
+            @RequestParam(value = "hubId", required = false) UUID hubId,
+            @RequestHeader(value = "X-User-Id", required = false) UUID userId,
+            @RequestHeader(value = "X-Roles", required = false) String role) {
+        // HUB 역할은 자신의 허브 내에서만 검색 가능: Service에서 강제
+        return ResponseEntity.ok(companyService.searchCompanyWithScope(name, hubId, userId, role));
     }
 
     // user id로 업체 단건 조회
@@ -43,8 +46,11 @@ public class CompanyController {
     }
 
     @PostMapping
-    public ResponseEntity<Void> createCompany(@Valid @RequestBody CompanySaveRequestDto companySaveRequestDto) {
-        companyService.createCompany(companySaveRequestDto);
+    public ResponseEntity<Void> createCompany(
+            @Valid @RequestBody CompanySaveRequestDto companySaveRequestDto,
+            @RequestHeader(value = "X-User-Id", required = false) UUID userId,
+            @RequestHeader(value = "X-Roles", required = false) String role) {
+        companyService.createCompanyWithAuth(companySaveRequestDto, userId, role);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/tunaforce/company/controller/CompanyController.java
+++ b/src/main/java/com/tunaforce/company/controller/CompanyController.java
@@ -1,5 +1,6 @@
 package com.tunaforce.company.controller;
 
+import com.tunaforce.company.dto.request.CompanyIdListRequestDto;
 import com.tunaforce.company.dto.request.CompanySaveRequestDto;
 import com.tunaforce.company.dto.response.CompanyListResponseDto;
 import com.tunaforce.company.dto.response.CompanyResponseDto;
@@ -28,6 +29,17 @@ public class CompanyController {
             @RequestParam(value = "name", required = false) String name,
             @RequestParam(value = "hubId", required = false) UUID hubId) {
         return ResponseEntity.ok(companyService.searchCompany(name, hubId));
+    }
+
+    // user id로 업체 단건 조회
+    @GetMapping("/users/{userId}")
+    public ResponseEntity<CompanyResponseDto> getCompanyByUserId(@PathVariable("userId") UUID userId){
+        return ResponseEntity.ok(companyService.searchCompanyByUserId(userId));
+    }
+
+    @PostMapping("/list")
+    public ResponseEntity<CompanyListResponseDto> searchCompanyByList(@RequestBody CompanyIdListRequestDto requestDto) {
+        return ResponseEntity.ok(companyService.searchCompanyByIdList(requestDto));
     }
 
     @PostMapping

--- a/src/main/java/com/tunaforce/company/controller/CompanyController.java
+++ b/src/main/java/com/tunaforce/company/controller/CompanyController.java
@@ -9,6 +9,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.UUID;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/companies")
@@ -24,7 +26,7 @@ public class CompanyController {
     @GetMapping
     public ResponseEntity<CompanyListResponseDto> searchCompany(
             @RequestParam(value = "name", required = false) String name,
-            @RequestParam(value = "hubId", required = false) String hubId) {
+            @RequestParam(value = "hubId", required = false) UUID hubId) {
         return ResponseEntity.ok(companyService.searchCompany(name, hubId));
     }
 
@@ -38,7 +40,7 @@ public class CompanyController {
     public ResponseEntity<Void> editCompanyInfo(
             @PathVariable("companyId") String companyId,
             @Valid @RequestBody CompanySaveRequestDto companySaveRequestDto,
-            @RequestHeader(value = "X-User-Id", required = false) String userId,
+            @RequestHeader(value = "X-User-Id", required = false) UUID userId,
             @RequestHeader(value = "X-User-Role", required = false) String userRole) {
         companyService.editCompanyInfo(companyId, companySaveRequestDto, userId, userRole);
         return ResponseEntity.ok().build();
@@ -47,7 +49,7 @@ public class CompanyController {
     @DeleteMapping("/{companyId}")
     public ResponseEntity<Void> deleteCompany(
             @PathVariable("companyId") String companyId,
-            @RequestHeader(value = "X-User-Id", required = false) String userId,
+            @RequestHeader(value = "X-User-Id", required = false) UUID userId,
             @RequestHeader(value = "X-User-Role", required = false) String userRole) {
         companyService.deleteCompany(companyId, userId, userRole);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/tunaforce/company/controller/CompanyController.java
+++ b/src/main/java/com/tunaforce/company/controller/CompanyController.java
@@ -20,7 +20,7 @@ public class CompanyController {
     private final CompanyService companyService;
 
     @GetMapping("/{companyId}")
-    public ResponseEntity<CompanyResponseDto> getCompanyInfo(@PathVariable("companyId") String companyId) {
+    public ResponseEntity<CompanyResponseDto> getCompanyInfo(@PathVariable("companyId") UUID companyId) {
         return ResponseEntity.ok(companyService.getCompanyInfo(companyId));
     }
 
@@ -50,7 +50,7 @@ public class CompanyController {
 
     @PatchMapping("/{companyId}")
     public ResponseEntity<Void> editCompanyInfo(
-            @PathVariable("companyId") String companyId,
+            @PathVariable("companyId") UUID companyId,
             @Valid @RequestBody CompanySaveRequestDto companySaveRequestDto,
             @RequestHeader(value = "X-User-Id", required = false) UUID userId,
             @RequestHeader(value = "X-Roles", required = false) String userRole) {
@@ -60,7 +60,7 @@ public class CompanyController {
 
     @DeleteMapping("/{companyId}")
     public ResponseEntity<Void> deleteCompany(
-            @PathVariable("companyId") String companyId,
+            @PathVariable("companyId") UUID companyId,
             @RequestHeader(value = "X-User-Id", required = false) UUID userId,
             @RequestHeader(value = "X-Roles", required = false) String userRole) {
         companyService.deleteCompany(companyId, userId, userRole);

--- a/src/main/java/com/tunaforce/company/dto/request/CompanyIdListRequestDto.java
+++ b/src/main/java/com/tunaforce/company/dto/request/CompanyIdListRequestDto.java
@@ -1,0 +1,9 @@
+package com.tunaforce.company.dto.request;
+
+import java.util.List;
+import java.util.UUID;
+
+public record CompanyIdListRequestDto(
+        List<UUID> companyIdList
+) {
+}

--- a/src/main/java/com/tunaforce/company/dto/request/CompanySaveRequestDto.java
+++ b/src/main/java/com/tunaforce/company/dto/request/CompanySaveRequestDto.java
@@ -1,10 +1,12 @@
 package com.tunaforce.company.dto.request;
 
+import java.util.UUID;
+
 public record CompanySaveRequestDto(
         String companyName,
         String type,
         String address,
-        String hubId,
-        String userId
+        UUID hubId,
+        UUID userId
 ) {
 }

--- a/src/main/java/com/tunaforce/company/dto/request/CompanySaveRequestDto.java
+++ b/src/main/java/com/tunaforce/company/dto/request/CompanySaveRequestDto.java
@@ -1,0 +1,10 @@
+package com.tunaforce.company.dto.request;
+
+public record CompanySaveRequestDto(
+        String companyName,
+        String type,
+        String address,
+        String hubId,
+        String userId
+) {
+}

--- a/src/main/java/com/tunaforce/company/dto/response/CompanyListResponseDto.java
+++ b/src/main/java/com/tunaforce/company/dto/response/CompanyListResponseDto.java
@@ -1,0 +1,7 @@
+package com.tunaforce.company.dto.response;
+
+import java.util.List;
+
+public record CompanyListResponseDto(
+	List<CompanyResponseDto> data
+) {}

--- a/src/main/java/com/tunaforce/company/dto/response/CompanyResponseDto.java
+++ b/src/main/java/com/tunaforce/company/dto/response/CompanyResponseDto.java
@@ -1,0 +1,12 @@
+package com.tunaforce.company.dto.response;
+
+import java.util.UUID;
+
+public record CompanyResponseDto(
+        UUID companyId,
+        String companyName,
+        String companyType,
+        String address,
+        String hubName
+) {
+}

--- a/src/main/java/com/tunaforce/company/dto/response/CompanyResponseDto.java
+++ b/src/main/java/com/tunaforce/company/dto/response/CompanyResponseDto.java
@@ -7,6 +7,7 @@ public record CompanyResponseDto(
         String companyName,
         String companyType,
         String address,
+        UUID hubId,
         String hubName
 ) {
 }

--- a/src/main/java/com/tunaforce/company/entity/Company.java
+++ b/src/main/java/com/tunaforce/company/entity/Company.java
@@ -19,7 +19,7 @@ public class Company extends Timestamped{
     private UUID companyId;
 
     @NotBlank
-    @Column(name = "company_name", unique = true, nullable = false, updatable = false)
+    @Column(name = "company_name", unique = true, nullable = false)
     private String companyName;
 
     @NotBlank
@@ -43,6 +43,24 @@ public class Company extends Timestamped{
         this.address = address;
         this.companyType = companyType;
         this.hubId = hubId;
+        this.userId = userId;
+    }
+
+    // 도메인 업데이트 메서드 (companyName, companyId는 변경 불가)
+    public void updateInfo(String companyName, String address, CompanyType companyType, UUID hubId, UUID userId) {
+        if (companyName != null && !companyName.isBlank()) {
+            this.companyName = companyName;
+        }
+        if (address != null && !address.isBlank()) {
+            this.address = address;
+        }
+        if (companyType != null) {
+            this.companyType = companyType;
+        }
+        if (hubId != null) {
+            this.hubId = hubId;
+        }
+        // userId는 null 허용(없으면 null 저장)
         this.userId = userId;
     }
 }

--- a/src/main/java/com/tunaforce/company/entity/Company.java
+++ b/src/main/java/com/tunaforce/company/entity/Company.java
@@ -2,6 +2,7 @@ package com.tunaforce.company.entity;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,7 +23,7 @@ public class Company extends Timestamped{
     @Column(name = "company_name", unique = true, nullable = false)
     private String companyName;
 
-    @NotBlank
+    @NotNull
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private CompanyType companyType;
@@ -31,7 +32,7 @@ public class Company extends Timestamped{
     @Column(nullable = false)
     private String address;
 
-    @NotBlank
+    @NotNull
     @Column(nullable = false)
     private UUID hubId;
 

--- a/src/main/java/com/tunaforce/company/exception/CompanyNotFoundException.java
+++ b/src/main/java/com/tunaforce/company/exception/CompanyNotFoundException.java
@@ -1,0 +1,7 @@
+package com.tunaforce.company.exception;
+
+public class CompanyNotFoundException extends RuntimeException {
+    public CompanyNotFoundException() {
+        super("요청하신 업체를 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/com/tunaforce/company/exception/ErrorResponse.java
+++ b/src/main/java/com/tunaforce/company/exception/ErrorResponse.java
@@ -1,0 +1,14 @@
+package com.tunaforce.company.exception;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ErrorResponse(
+        int code,
+        String error,
+        String message
+) {
+    public static ErrorResponse notFound(String message) {
+        return new ErrorResponse(404, "NOT_FOUND", message);
+    }
+}

--- a/src/main/java/com/tunaforce/company/exception/ForbiddenException.java
+++ b/src/main/java/com/tunaforce/company/exception/ForbiddenException.java
@@ -1,0 +1,7 @@
+package com.tunaforce.company.exception;
+
+public class ForbiddenException extends RuntimeException {
+    public ForbiddenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/tunaforce/company/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/tunaforce/company/exception/GlobalExceptionHandler.java
@@ -13,4 +13,10 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
                 .body(ErrorResponse.notFound(ex.getMessage()));
     }
+
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<ErrorResponse> handleForbidden(ForbiddenException ex) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(new ErrorResponse(403, "FORBIDDEN", ex.getMessage()));
+    }
 }

--- a/src/main/java/com/tunaforce/company/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/tunaforce/company/exception/GlobalExceptionHandler.java
@@ -1,0 +1,16 @@
+package com.tunaforce.company.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CompanyNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleCompanyNotFound(CompanyNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ErrorResponse.notFound(ex.getMessage()));
+    }
+}

--- a/src/main/java/com/tunaforce/company/repository/CompanyRepository.java
+++ b/src/main/java/com/tunaforce/company/repository/CompanyRepository.java
@@ -5,10 +5,16 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface CompanyRepository extends JpaRepository<Company, UUID> {
     @Query("SELECT c FROM Company c WHERE (:name IS NULL OR LOWER(c.companyName) LIKE LOWER(CONCAT('%', :name, '%'))) " +
 	    "AND (:hubId IS NULL OR c.hubId = :hubId)")
     List<Company> search(String name, UUID hubId);
+
+    // Soft-delete 고려: deletedAt IS NULL
+    List<Company> findByCompanyIdInAndDeletedAtIsNull(List<UUID> companyIds);
+
+    Optional<Company> findFirstByUserIdAndDeletedAtIsNull(UUID userId);
 }

--- a/src/main/java/com/tunaforce/company/repository/CompanyRepository.java
+++ b/src/main/java/com/tunaforce/company/repository/CompanyRepository.java
@@ -2,8 +2,13 @@ package com.tunaforce.company.repository;
 
 import com.tunaforce.company.entity.Company;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface CompanyRepository extends JpaRepository<Company, UUID> {
+    @Query("SELECT c FROM Company c WHERE (:name IS NULL OR LOWER(c.companyName) LIKE LOWER(CONCAT('%', :name, '%'))) " +
+	    "AND (:hubId IS NULL OR c.hubId = :hubId)")
+    List<Company> search(String name, UUID hubId);
 }

--- a/src/main/java/com/tunaforce/company/repository/CompanyRepository.java
+++ b/src/main/java/com/tunaforce/company/repository/CompanyRepository.java
@@ -9,8 +9,11 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface CompanyRepository extends JpaRepository<Company, UUID> {
-    @Query("SELECT c FROM Company c WHERE (:name IS NULL OR LOWER(c.companyName) LIKE LOWER(CONCAT('%', :name, '%'))) " +
-	    "AND (:hubId IS NULL OR c.hubId = :hubId)")
+    @Query(value = "SELECT * FROM p_company c WHERE " +
+            "(:name IS NULL OR LOWER(c.company_name) LIKE LOWER('%' || :name || '%')) " +
+            "AND (:hubId IS NULL OR c.hub_id = CAST(:hubId AS UUID)) " +
+            "AND c.deleted_at IS NULL",
+            nativeQuery = true)
     List<Company> search(String name, UUID hubId);
 
     // Soft-delete 고려: deletedAt IS NULL

--- a/src/main/java/com/tunaforce/company/repository/CompanyRepository.java
+++ b/src/main/java/com/tunaforce/company/repository/CompanyRepository.java
@@ -1,0 +1,9 @@
+package com.tunaforce.company.repository;
+
+import com.tunaforce.company.entity.Company;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface CompanyRepository extends JpaRepository<Company, UUID> {
+}

--- a/src/main/java/com/tunaforce/company/service/CompanyService.java
+++ b/src/main/java/com/tunaforce/company/service/CompanyService.java
@@ -27,17 +27,10 @@ public class CompanyService {
     private final CompanyRepository companyRepository;
     private final HubClient hubClient;
 
-    public CompanyResponseDto getCompanyInfo(String companyId) {
-        Company company = companyRepository.findById(UUID.fromString(companyId))
+    public CompanyResponseDto getCompanyInfo(UUID companyId) {
+        Company company = companyRepository.findById(companyId)
                 .orElseThrow(CompanyNotFoundException::new);
-
-        String hubName = null;
-        try {
-            HubGetResponse hub = hubClient.getHub(company.getHubId());
-            hubName = hub != null ? hub.hubName() : null;
-        } catch (Exception ignored) {
-            // 허브 서비스 장애 시 hubName은 null 유지
-        }
+        String hubName = resolveHubName(company.getHubId());
         return new CompanyResponseDto(
                 company.getCompanyId(),
                 company.getCompanyName(),
@@ -53,28 +46,7 @@ public class CompanyService {
 
         List<Company> companies = companyRepository.search(normalizedName, hubId);
 
-        // 요청 단위 로컬 캐시로 동일 hubId 중복 호출 방지
-        Map<UUID, String> hubNameCache = new HashMap<>();
-
-        List<CompanyResponseDto> items = companies.stream().map(c -> {
-            String hubName = hubNameCache.computeIfAbsent(c.getHubId(), hid -> {
-                try {
-                    HubGetResponse hub = hubClient.getHub(hid);
-                    return hub != null ? hub.hubName() : null;
-                } catch (Exception ignored) {
-                    return null;
-                }
-            });
-            return new CompanyResponseDto(
-                    c.getCompanyId(),
-                    c.getCompanyName(),
-                    c.getCompanyType().name(),
-                    c.getAddress(),
-                    hubName
-            );
-        }).collect(Collectors.toList());
-
-        return new CompanyListResponseDto(items);
+    return toCompanyListResponse(companies);
     }
 
     @Transactional
@@ -89,9 +61,9 @@ public class CompanyService {
     }
 
     @Transactional
-    public void editCompanyInfo(String companyId, @Valid CompanySaveRequestDto companySaveRequestDto,
+    public void editCompanyInfo(UUID companyId, @Valid CompanySaveRequestDto companySaveRequestDto,
                                 UUID headerUserId, String headerUserRole) {
-        Company company = companyRepository.findById(UUID.fromString(companyId)).orElseThrow(CompanyNotFoundException::new);
+        Company company = companyRepository.findById(companyId).orElseThrow(CompanyNotFoundException::new);
 
         // 권한: MASTER/HUB 이거나 소유자(userId 일치)
         boolean isPrivileged = headerUserRole != null && (
@@ -114,8 +86,8 @@ public class CompanyService {
     }
 
     @Transactional
-    public void deleteCompany(String companyId, UUID headerUserId, String headerUserRole) {
-        Company company = companyRepository.findById(UUID.fromString(companyId))
+    public void deleteCompany(UUID companyId, UUID headerUserId, String headerUserRole) {
+        Company company = companyRepository.findById(companyId)
                 .orElseThrow(CompanyNotFoundException::new);
 
         // 간단한 권한 체크: ADMIN/HUB는 모두 허용, 아니면 company.userId와 일치해야 함
@@ -138,40 +110,14 @@ public class CompanyService {
         }
 
         List<Company> companies = companyRepository.findByCompanyIdInAndDeletedAtIsNull(ids);
-
-        Map<UUID, String> hubNameCache = new HashMap<>();
-        List<CompanyResponseDto> items = companies.stream().map(c -> {
-            String hubName = hubNameCache.computeIfAbsent(c.getHubId(), hid -> {
-                try {
-                    HubGetResponse hub = hubClient.getHub(hid);
-                    return hub != null ? hub.hubName() : null;
-                } catch (Exception ignored) {
-                    return null;
-                }
-            });
-            return new CompanyResponseDto(
-                    c.getCompanyId(),
-                    c.getCompanyName(),
-                    c.getCompanyType().name(),
-                    c.getAddress(),
-                    hubName
-            );
-        }).collect(Collectors.toList());
-
-        return new CompanyListResponseDto(items);
+    return toCompanyListResponse(companies);
     }
 
     public CompanyResponseDto searchCompanyByUserId(UUID userId) {
         Company company = companyRepository.findFirstByUserIdAndDeletedAtIsNull(userId)
                 .orElseThrow(CompanyNotFoundException::new);
 
-        String hubName = null;
-        try {
-            HubGetResponse hub = hubClient.getHub(company.getHubId());
-            hubName = hub != null ? hub.hubName() : null;
-        } catch (Exception ignored) {
-            // 허브 서비스 장애 시 hubName은 null 유지
-        }
+        String hubName = resolveHubName(company.getHubId());
 
         return new CompanyResponseDto(
                 company.getCompanyId(),
@@ -180,5 +126,39 @@ public class CompanyService {
                 company.getAddress(),
                 hubName
         );
+    }
+
+    // hubName 조회 중복 로직 추출: per-request 캐시를 사용해 허브 서비스 중복 호출 방지
+    private String resolveHubName(UUID hubId, Map<UUID, String> cache) {
+        if (hubId == null) return null;
+        return cache.computeIfAbsent(hubId, hid -> {
+            try {
+                HubGetResponse hub = hubClient.getHub(hid);
+                return hub != null ? hub.hubName() : null;
+            } catch (Exception ignored) {
+                return null;
+            }
+        });
+    }
+
+    // 단건 조회용 편의 메서드
+    private String resolveHubName(UUID hubId) {
+        return resolveHubName(hubId, new HashMap<>());
+    }
+
+    // 공통: Company 리스트를 DTO 리스트로 변환하며 hubName 조회에 요청 단위 캐시 적용
+    private CompanyListResponseDto toCompanyListResponse(List<Company> companies) {
+        Map<UUID, String> hubNameCache = new HashMap<>();
+        List<CompanyResponseDto> items = companies.stream().map(c -> {
+            String hubName = resolveHubName(c.getHubId(), hubNameCache);
+            return new CompanyResponseDto(
+                    c.getCompanyId(),
+                    c.getCompanyName(),
+                    c.getCompanyType().name(),
+                    c.getAddress(),
+                    hubName
+            );
+        }).collect(Collectors.toList());
+        return new CompanyListResponseDto(items);
     }
 }

--- a/src/main/java/com/tunaforce/company/service/CompanyService.java
+++ b/src/main/java/com/tunaforce/company/service/CompanyService.java
@@ -9,6 +9,7 @@ import com.tunaforce.company.entity.CompanyType;
 import com.tunaforce.company.exception.CompanyNotFoundException;
 import com.tunaforce.company.repository.CompanyRepository;
 import com.tunaforce.company.client.HubClient;
+import com.tunaforce.company.client.dto.HubByAdminResponse;
 import com.tunaforce.company.client.dto.HubGetResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -46,17 +47,65 @@ public class CompanyService {
 
         List<Company> companies = companyRepository.search(normalizedName, hubId);
 
-    return toCompanyListResponse(companies);
+        return toCompanyListResponse(companies);
+    }
+
+    // 역할 기반 조회 범위 강제 버전 (Controller에서 호출)
+    public CompanyListResponseDto searchCompanyWithScope(String name, UUID hubId,
+                                                         UUID headerUserId, String headerUserRole) {
+        String role = headerUserRole == null ? "" : headerUserRole.toUpperCase();
+
+        UUID effectiveHubId = hubId;
+        if ("HUB".equals(role)) {
+            // 허브 관리자는 자신의 허브로만 제한
+            try {
+                HubByAdminResponse hubInfo = hubClient.getHubByAdmin(headerUserId);
+                if (hubInfo == null || hubInfo.hubId() == null) {
+                    // 허브 정보를 확인할 수 없으면 검색 허용하지 않음
+                    return new CompanyListResponseDto(List.of());
+                }
+                effectiveHubId = hubInfo.hubId();
+            } catch (Exception ignore) {
+            }
+        }
+        // MASTER, COMPANY, DELIVERY: 읽기 권한은 허용 (필요 시 세분화 가능)
+        return searchCompany(name, effectiveHubId);
     }
 
     @Transactional
-    public void createCompany(@Valid CompanySaveRequestDto companySaveRequestDto) {
+    public void createCompanyWithAuth(@Valid CompanySaveRequestDto dto,
+                                      UUID headerUserId, String headerUserRole) {
+        String role = headerUserRole == null ? "" : headerUserRole.toUpperCase();
+
+        if ("MASTER".equals(role)) {
+            // 모두 허용
+        } else if ("HUB".equals(role)) {
+            // 허브 관리자는 자신의 허브에 소속된 업체만 생성 가능
+            UUID adminHubId = null;
+            try {
+                HubByAdminResponse hubInfo = hubClient.getHubByAdmin(headerUserId);
+                if (hubInfo != null) adminHubId = hubInfo.hubId();
+            } catch (Exception ignore) {
+            }
+            if (adminHubId == null || dto.hubId() == null || !adminHubId.equals(dto.hubId())) {
+                throw new com.tunaforce.company.exception.ForbiddenException("허브 관리자는 소속 허브의 업체만 생성할 수 있습니다.");
+            }
+        } else if ("COMPANY".equals(role)) {
+            // 업체 담당자는 자신의 업체만 생성 가능(본인 userId로 생성)
+            if (dto.userId() == null || !dto.userId().equals(headerUserId)) {
+                throw new com.tunaforce.company.exception.ForbiddenException("업체 담당자는 자신의 userId로만 업체를 생성할 수 있습니다.");
+            }
+            // 허브 소속 제한은 정책에 따라 필요 시 추가 가능
+        } else {
+            throw new com.tunaforce.company.exception.ForbiddenException("생성 권한이 없습니다.");
+        }
+
         companyRepository.save(Company.builder()
-                .companyName(companySaveRequestDto.companyName())
-                .address(companySaveRequestDto.address())
-                .companyType(CompanyType.fromString(companySaveRequestDto.type()))
-                .hubId(companySaveRequestDto.hubId())
-                .userId(companySaveRequestDto.userId())
+                .companyName(dto.companyName())
+                .address(dto.address())
+                .companyType(CompanyType.fromString(dto.type()))
+                .hubId(dto.hubId())
+                .userId(dto.userId())
                 .build());
     }
 
@@ -65,13 +114,38 @@ public class CompanyService {
                                 UUID headerUserId, String headerUserRole) {
         Company company = companyRepository.findById(companyId).orElseThrow(CompanyNotFoundException::new);
 
-        // 권한: MASTER/HUB 이거나 소유자(userId 일치)
-        boolean isPrivileged = headerUserRole != null && (
-                headerUserRole.equalsIgnoreCase("MASTER") || headerUserRole.equalsIgnoreCase("HUB")
-        );
-        boolean isOwner = company.getUserId() != null && company.getUserId().equals(headerUserId);
-        if (!(isPrivileged || isOwner)) {
-            throw new com.tunaforce.company.exception.ForbiddenException("수정 권한이 없습니다.");
+        // 권한 정책
+        // - MASTER: 모두 허용
+        // - HUB: 자신의 허브 소속 업체만 수정 가능
+        // - COMPANY(업체 담당자): 자신의 업체만 수정 가능
+        String role = headerUserRole == null ? "" : headerUserRole.toUpperCase();
+        boolean isMaster = role.equals("MASTER");
+        boolean isHub = role.equals("HUB");
+        boolean isCompany = role.equals("COMPANY");
+
+        if (!isMaster) {
+            if (isHub) {
+                // 허브 관리자의 소속 허브를 허브 서비스에서 조회
+                // 토큰 subject=사용자 ID
+                UUID adminHubId = null;
+                try {
+                    HubByAdminResponse hubInfo = hubClient.getHubByAdmin(headerUserId);
+                    if (hubInfo != null) adminHubId = hubInfo.hubId();
+                } catch (Exception ignore) {
+                }
+
+                if (adminHubId == null || !adminHubId.equals(company.getHubId())) {
+                    throw new com.tunaforce.company.exception.ForbiddenException("허브 관리자 권한으로는 소속 허브 내 업체만 수정 가능합니다.");
+                }
+            } else if (isCompany) {
+                // 업체 담당자는 본인 업체만
+                if (company.getUserId() == null || !company.getUserId().equals(headerUserId)) {
+                    throw new com.tunaforce.company.exception.ForbiddenException("업체 담당자는 자신의 업체만 수정할 수 있습니다.");
+                }
+            } else {
+                // 그 외 권한 없음
+                throw new com.tunaforce.company.exception.ForbiddenException("수정 권한이 없습니다.");
+            }
         }
         // hubId/userId는 DTO에서 바로 UUID로 전달됨
 
@@ -90,13 +164,25 @@ public class CompanyService {
         Company company = companyRepository.findById(companyId)
                 .orElseThrow(CompanyNotFoundException::new);
 
-        // 간단한 권한 체크: ADMIN/HUB는 모두 허용, 아니면 company.userId와 일치해야 함
-        boolean isPrivileged = headerUserRole != null && (
-                headerUserRole.equalsIgnoreCase("ADMIN") || headerUserRole.equalsIgnoreCase("HUB")
-        );
-        boolean isOwner = company.getUserId() != null && company.getUserId().equals(headerUserId);
+        // 삭제 권한 정책
+        // - MASTER: 모두 허용
+        // - HUB: 자신의 허브 소속 업체만 삭제 가능
+        // - COMPANY: 삭제 불가
+        String role = headerUserRole == null ? "" : headerUserRole.toUpperCase();
+        if ("MASTER".equals(role)) {
+            // ok
+        } else if ("HUB".equals(role)) {
+            UUID adminHubId = null;
+            try {
+                HubByAdminResponse hubInfo = hubClient.getHubByAdmin(headerUserId);
+                if (hubInfo != null) adminHubId = hubInfo.hubId();
+            } catch (Exception ignore) {
+            }
 
-        if (!(isPrivileged || isOwner)) {
+            if (adminHubId == null || !adminHubId.equals(company.getHubId())) {
+                throw new com.tunaforce.company.exception.ForbiddenException("허브 관리자는 소속 허브 내 업체만 삭제할 수 있습니다.");
+            }
+        } else {
             throw new com.tunaforce.company.exception.ForbiddenException("삭제 권한이 없습니다.");
         }
 
@@ -110,7 +196,7 @@ public class CompanyService {
         }
 
         List<Company> companies = companyRepository.findByCompanyIdInAndDeletedAtIsNull(ids);
-    return toCompanyListResponse(companies);
+        return toCompanyListResponse(companies);
     }
 
     public CompanyResponseDto searchCompanyByUserId(UUID userId) {

--- a/src/main/java/com/tunaforce/company/service/CompanyService.java
+++ b/src/main/java/com/tunaforce/company/service/CompanyService.java
@@ -1,5 +1,6 @@
 package com.tunaforce.company.service;
 
+import com.tunaforce.company.dto.response.CompanyListResponseDto;
 import com.tunaforce.company.dto.response.CompanyResponseDto;
 import com.tunaforce.company.entity.Company;
 import com.tunaforce.company.exception.CompanyNotFoundException;
@@ -9,7 +10,11 @@ import com.tunaforce.company.client.dto.HubGetResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -35,5 +40,40 @@ public class CompanyService {
                 company.getAddress(),
                 hubName
         );
+    }
+
+    public CompanyListResponseDto searchCompany(String name, String hubId) {
+        // 빈 문자열은 null로 정규화 -> 전체 검색 동작 보장
+        String normalizedName = (name == null || name.isBlank()) ? null : name;
+
+        UUID hubUUID = null;
+        if (hubId != null && !hubId.isBlank()) {
+            try { hubUUID = UUID.fromString(hubId); } catch (IllegalArgumentException ignored) {}
+        }
+
+        List<Company> companies = companyRepository.search(normalizedName, hubUUID);
+
+        // 요청 단위 로컬 캐시로 동일 hubId 중복 호출 방지
+        Map<UUID, String> hubNameCache = new HashMap<>();
+
+        List<CompanyResponseDto> items = companies.stream().map(c -> {
+            String hubName = hubNameCache.computeIfAbsent(c.getHubId(), hid -> {
+                try {
+                    HubGetResponse hub = hubClient.getHub(hid);
+                    return hub != null ? hub.hubName() : null;
+                } catch (Exception ignored) {
+                    return null;
+                }
+            });
+            return new CompanyResponseDto(
+                    c.getCompanyId(),
+                    c.getCompanyName(),
+                    c.getCompanyType().name(),
+                    c.getAddress(),
+                    hubName
+            );
+        }).collect(Collectors.toList());
+
+        return new CompanyListResponseDto(items);
     }
 }

--- a/src/main/java/com/tunaforce/company/service/CompanyService.java
+++ b/src/main/java/com/tunaforce/company/service/CompanyService.java
@@ -1,0 +1,39 @@
+package com.tunaforce.company.service;
+
+import com.tunaforce.company.dto.response.CompanyResponseDto;
+import com.tunaforce.company.entity.Company;
+import com.tunaforce.company.exception.CompanyNotFoundException;
+import com.tunaforce.company.repository.CompanyRepository;
+import com.tunaforce.company.client.HubClient;
+import com.tunaforce.company.client.dto.HubGetResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class CompanyService {
+    private final CompanyRepository companyRepository;
+    private final HubClient hubClient;
+
+    public CompanyResponseDto getCompanyInfo(String companyId) {
+        Company company = companyRepository.findById(UUID.fromString(companyId))
+                .orElseThrow(CompanyNotFoundException::new);
+
+        String hubName = null;
+        try {
+            HubGetResponse hub = hubClient.getHub(company.getHubId());
+            hubName = hub != null ? hub.hubName() : null;
+        } catch (Exception ignored) {
+            // 허브 서비스 장애 시 hubName은 null 유지
+        }
+        return new CompanyResponseDto(
+                company.getCompanyId(),
+                company.getCompanyName(),
+                company.getCompanyType().name(),
+                company.getAddress(),
+                hubName
+        );
+    }
+}

--- a/src/main/java/com/tunaforce/company/service/CompanyService.java
+++ b/src/main/java/com/tunaforce/company/service/CompanyService.java
@@ -90,13 +90,8 @@ public class CompanyService {
             if (adminHubId == null || dto.hubId() == null || !adminHubId.equals(dto.hubId())) {
                 throw new com.tunaforce.company.exception.ForbiddenException("허브 관리자는 소속 허브의 업체만 생성할 수 있습니다.");
             }
-        } else if ("COMPANY".equals(role)) {
-            // 업체 담당자는 자신의 업체만 생성 가능(본인 userId로 생성)
-            if (dto.userId() == null || !dto.userId().equals(headerUserId)) {
-                throw new com.tunaforce.company.exception.ForbiddenException("업체 담당자는 자신의 userId로만 업체를 생성할 수 있습니다.");
-            }
-            // 허브 소속 제한은 정책에 따라 필요 시 추가 가능
         } else {
+            // 업체 담당자, delivery는 생성 불가능
             throw new com.tunaforce.company.exception.ForbiddenException("생성 권한이 없습니다.");
         }
 

--- a/src/main/java/com/tunaforce/company/service/CompanyService.java
+++ b/src/main/java/com/tunaforce/company/service/CompanyService.java
@@ -1,5 +1,6 @@
 package com.tunaforce.company.service;
 
+import com.tunaforce.company.dto.request.CompanyIdListRequestDto;
 import com.tunaforce.company.dto.request.CompanySaveRequestDto;
 import com.tunaforce.company.dto.response.CompanyListResponseDto;
 import com.tunaforce.company.dto.response.CompanyResponseDto;
@@ -128,5 +129,56 @@ public class CompanyService {
         }
 
         company.delete(headerUserId);
+    }
+
+    public CompanyListResponseDto searchCompanyByIdList(CompanyIdListRequestDto requestDto) {
+        List<UUID> ids = (requestDto == null) ? null : requestDto.companyIdList();
+        if (ids == null || ids.isEmpty()) {
+            return new CompanyListResponseDto(List.of());
+        }
+
+        List<Company> companies = companyRepository.findByCompanyIdInAndDeletedAtIsNull(ids);
+
+        Map<UUID, String> hubNameCache = new HashMap<>();
+        List<CompanyResponseDto> items = companies.stream().map(c -> {
+            String hubName = hubNameCache.computeIfAbsent(c.getHubId(), hid -> {
+                try {
+                    HubGetResponse hub = hubClient.getHub(hid);
+                    return hub != null ? hub.hubName() : null;
+                } catch (Exception ignored) {
+                    return null;
+                }
+            });
+            return new CompanyResponseDto(
+                    c.getCompanyId(),
+                    c.getCompanyName(),
+                    c.getCompanyType().name(),
+                    c.getAddress(),
+                    hubName
+            );
+        }).collect(Collectors.toList());
+
+        return new CompanyListResponseDto(items);
+    }
+
+    public CompanyResponseDto searchCompanyByUserId(UUID userId) {
+        Company company = companyRepository.findFirstByUserIdAndDeletedAtIsNull(userId)
+                .orElseThrow(CompanyNotFoundException::new);
+
+        String hubName = null;
+        try {
+            HubGetResponse hub = hubClient.getHub(company.getHubId());
+            hubName = hub != null ? hub.hubName() : null;
+        } catch (Exception ignored) {
+            // 허브 서비스 장애 시 hubName은 null 유지
+        }
+
+        return new CompanyResponseDto(
+                company.getCompanyId(),
+                company.getCompanyName(),
+                company.getCompanyType().name(),
+                company.getAddress(),
+                hubName
+        );
     }
 }

--- a/src/main/java/com/tunaforce/company/service/CompanyService.java
+++ b/src/main/java/com/tunaforce/company/service/CompanyService.java
@@ -37,6 +37,7 @@ public class CompanyService {
                 company.getCompanyName(),
                 company.getCompanyType().name(),
                 company.getAddress(),
+                company.getHubId(),
                 hubName
         );
     }
@@ -205,6 +206,7 @@ public class CompanyService {
                 company.getCompanyName(),
                 company.getCompanyType().name(),
                 company.getAddress(),
+                company.getHubId(),
                 hubName
         );
     }
@@ -237,6 +239,7 @@ public class CompanyService {
                     c.getCompanyName(),
                     c.getCompanyType().name(),
                     c.getAddress(),
+                    c.getHubId(),
                     hubName
             );
         }).collect(Collectors.toList());

--- a/src/main/java/com/tunaforce/company/service/CompanyService.java
+++ b/src/main/java/com/tunaforce/company/service/CompanyService.java
@@ -1,14 +1,18 @@
 package com.tunaforce.company.service;
 
+import com.tunaforce.company.dto.request.CompanySaveRequestDto;
 import com.tunaforce.company.dto.response.CompanyListResponseDto;
 import com.tunaforce.company.dto.response.CompanyResponseDto;
 import com.tunaforce.company.entity.Company;
+import com.tunaforce.company.entity.CompanyType;
 import com.tunaforce.company.exception.CompanyNotFoundException;
 import com.tunaforce.company.repository.CompanyRepository;
 import com.tunaforce.company.client.HubClient;
 import com.tunaforce.company.client.dto.HubGetResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashMap;
 import java.util.List;
@@ -48,7 +52,10 @@ public class CompanyService {
 
         UUID hubUUID = null;
         if (hubId != null && !hubId.isBlank()) {
-            try { hubUUID = UUID.fromString(hubId); } catch (IllegalArgumentException ignored) {}
+            try {
+                hubUUID = UUID.fromString(hubId);
+            } catch (IllegalArgumentException ignored) {
+            }
         }
 
         List<Company> companies = companyRepository.search(normalizedName, hubUUID);
@@ -75,5 +82,85 @@ public class CompanyService {
         }).collect(Collectors.toList());
 
         return new CompanyListResponseDto(items);
+    }
+
+    @Transactional
+    public void createCompany(@Valid CompanySaveRequestDto companySaveRequestDto) {
+        UUID userId = null;
+        if (companySaveRequestDto.userId() != null && !companySaveRequestDto.userId().isBlank()) {
+            userId = UUID.fromString(companySaveRequestDto.userId());
+        }
+
+        companyRepository.save(Company.builder()
+                .companyName(companySaveRequestDto.companyName())
+                .address(companySaveRequestDto.address())
+                .companyType(CompanyType.fromString(companySaveRequestDto.type()))
+                .hubId(UUID.fromString(companySaveRequestDto.hubId()))
+                .userId(userId)
+                .build());
+    }
+
+    @Transactional
+    public void editCompanyInfo(String companyId, @Valid CompanySaveRequestDto companySaveRequestDto,
+                                String headerUserId, String headerUserRole) {
+        Company company = companyRepository.findById(UUID.fromString(companyId)).orElseThrow(CompanyNotFoundException::new);
+
+        // 권한: MASTER/HUB 이거나 소유자(userId 일치)
+        boolean isPrivileged = headerUserRole != null && (
+                headerUserRole.equalsIgnoreCase("MASTER") || headerUserRole.equalsIgnoreCase("HUB")
+        );
+        boolean isOwner = false;
+        if (headerUserId != null && !headerUserId.isBlank() && company.getUserId() != null) {
+            try {
+                isOwner = company.getUserId().equals(UUID.fromString(headerUserId));
+            } catch (IllegalArgumentException ignored) {}
+        }
+        if (!(isPrivileged || isOwner)) {
+            throw new com.tunaforce.company.exception.ForbiddenException("수정 권한이 없습니다.");
+        }
+    // hubId는 필수(검증 어노테이션 존재). 값이 온 경우만 파싱 실패 방지
+        UUID hubId = UUID.fromString(companySaveRequestDto.hubId());
+
+        // userId는 선택 입력
+        UUID userId = null;
+        if (companySaveRequestDto.userId() != null && !companySaveRequestDto.userId().isBlank()) {
+            userId = UUID.fromString(companySaveRequestDto.userId());
+        }
+
+        company.updateInfo(
+                companySaveRequestDto.companyName(),
+                companySaveRequestDto.address(),
+                CompanyType.fromString(companySaveRequestDto.type()),
+                hubId,
+                userId
+        );
+
+    }
+
+    @Transactional
+    public void deleteCompany(String companyId, String headerUserId, String headerUserRole) {
+        Company company = companyRepository.findById(UUID.fromString(companyId))
+                .orElseThrow(CompanyNotFoundException::new);
+
+    // 간단한 권한 체크: ADMIN/HUB는 모두 허용, 아니면 company.userId와 일치해야 함
+    boolean isPrivileged = headerUserRole != null && (
+        headerUserRole.equalsIgnoreCase("ADMIN") || headerUserRole.equalsIgnoreCase("HUB")
+    );
+        boolean isOwner = false;
+        if (headerUserId != null && !headerUserId.isBlank() && company.getUserId() != null) {
+            try {
+                isOwner = company.getUserId().equals(UUID.fromString(headerUserId));
+            } catch (IllegalArgumentException ignored) { /* 잘못된 UUID는 소유자 아님 */ }
+        }
+
+    if (!(isPrivileged || isOwner)) {
+            throw new com.tunaforce.company.exception.ForbiddenException("삭제 권한이 없습니다.");
+        }
+
+        UUID deletedBy = null;
+        if (headerUserId != null && !headerUserId.isBlank()) {
+            try { deletedBy = UUID.fromString(headerUserId); } catch (IllegalArgumentException ignored) {}
+        }
+        company.delete(deletedBy);
     }
 }

--- a/src/main/java/com/tunaforce/company/service/CompanyService.java
+++ b/src/main/java/com/tunaforce/company/service/CompanyService.java
@@ -46,19 +46,11 @@ public class CompanyService {
         );
     }
 
-    public CompanyListResponseDto searchCompany(String name, String hubId) {
+    public CompanyListResponseDto searchCompany(String name, UUID hubId) {
         // 빈 문자열은 null로 정규화 -> 전체 검색 동작 보장
         String normalizedName = (name == null || name.isBlank()) ? null : name;
 
-        UUID hubUUID = null;
-        if (hubId != null && !hubId.isBlank()) {
-            try {
-                hubUUID = UUID.fromString(hubId);
-            } catch (IllegalArgumentException ignored) {
-            }
-        }
-
-        List<Company> companies = companyRepository.search(normalizedName, hubUUID);
+        List<Company> companies = companyRepository.search(normalizedName, hubId);
 
         // 요청 단위 로컬 캐시로 동일 hubId 중복 호출 방지
         Map<UUID, String> hubNameCache = new HashMap<>();
@@ -86,81 +78,55 @@ public class CompanyService {
 
     @Transactional
     public void createCompany(@Valid CompanySaveRequestDto companySaveRequestDto) {
-        UUID userId = null;
-        if (companySaveRequestDto.userId() != null && !companySaveRequestDto.userId().isBlank()) {
-            userId = UUID.fromString(companySaveRequestDto.userId());
-        }
-
         companyRepository.save(Company.builder()
                 .companyName(companySaveRequestDto.companyName())
                 .address(companySaveRequestDto.address())
                 .companyType(CompanyType.fromString(companySaveRequestDto.type()))
-                .hubId(UUID.fromString(companySaveRequestDto.hubId()))
-                .userId(userId)
+                .hubId(companySaveRequestDto.hubId())
+                .userId(companySaveRequestDto.userId())
                 .build());
     }
 
     @Transactional
     public void editCompanyInfo(String companyId, @Valid CompanySaveRequestDto companySaveRequestDto,
-                                String headerUserId, String headerUserRole) {
+                                UUID headerUserId, String headerUserRole) {
         Company company = companyRepository.findById(UUID.fromString(companyId)).orElseThrow(CompanyNotFoundException::new);
 
         // 권한: MASTER/HUB 이거나 소유자(userId 일치)
         boolean isPrivileged = headerUserRole != null && (
                 headerUserRole.equalsIgnoreCase("MASTER") || headerUserRole.equalsIgnoreCase("HUB")
         );
-        boolean isOwner = false;
-        if (headerUserId != null && !headerUserId.isBlank() && company.getUserId() != null) {
-            try {
-                isOwner = company.getUserId().equals(UUID.fromString(headerUserId));
-            } catch (IllegalArgumentException ignored) {}
-        }
+        boolean isOwner = company.getUserId() != null && company.getUserId().equals(headerUserId);
         if (!(isPrivileged || isOwner)) {
             throw new com.tunaforce.company.exception.ForbiddenException("수정 권한이 없습니다.");
         }
-    // hubId는 필수(검증 어노테이션 존재). 값이 온 경우만 파싱 실패 방지
-        UUID hubId = UUID.fromString(companySaveRequestDto.hubId());
-
-        // userId는 선택 입력
-        UUID userId = null;
-        if (companySaveRequestDto.userId() != null && !companySaveRequestDto.userId().isBlank()) {
-            userId = UUID.fromString(companySaveRequestDto.userId());
-        }
+        // hubId/userId는 DTO에서 바로 UUID로 전달됨
 
         company.updateInfo(
                 companySaveRequestDto.companyName(),
                 companySaveRequestDto.address(),
                 CompanyType.fromString(companySaveRequestDto.type()),
-                hubId,
-                userId
+                companySaveRequestDto.hubId(),
+                companySaveRequestDto.userId()
         );
 
     }
 
     @Transactional
-    public void deleteCompany(String companyId, String headerUserId, String headerUserRole) {
+    public void deleteCompany(String companyId, UUID headerUserId, String headerUserRole) {
         Company company = companyRepository.findById(UUID.fromString(companyId))
                 .orElseThrow(CompanyNotFoundException::new);
 
-    // 간단한 권한 체크: ADMIN/HUB는 모두 허용, 아니면 company.userId와 일치해야 함
-    boolean isPrivileged = headerUserRole != null && (
-        headerUserRole.equalsIgnoreCase("ADMIN") || headerUserRole.equalsIgnoreCase("HUB")
-    );
-        boolean isOwner = false;
-        if (headerUserId != null && !headerUserId.isBlank() && company.getUserId() != null) {
-            try {
-                isOwner = company.getUserId().equals(UUID.fromString(headerUserId));
-            } catch (IllegalArgumentException ignored) { /* 잘못된 UUID는 소유자 아님 */ }
-        }
+        // 간단한 권한 체크: ADMIN/HUB는 모두 허용, 아니면 company.userId와 일치해야 함
+        boolean isPrivileged = headerUserRole != null && (
+                headerUserRole.equalsIgnoreCase("ADMIN") || headerUserRole.equalsIgnoreCase("HUB")
+        );
+        boolean isOwner = company.getUserId() != null && company.getUserId().equals(headerUserId);
 
-    if (!(isPrivileged || isOwner)) {
+        if (!(isPrivileged || isOwner)) {
             throw new com.tunaforce.company.exception.ForbiddenException("삭제 권한이 없습니다.");
         }
 
-        UUID deletedBy = null;
-        if (headerUserId != null && !headerUserId.isBlank()) {
-            try { deletedBy = UUID.fromString(headerUserId); } catch (IllegalArgumentException ignored) {}
-        }
-        company.delete(deletedBy);
+        company.delete(headerUserId);
     }
 }


### PR DESCRIPTION
## 작업 내용
> Company 서비스에 허브 이름 조회(OpenFeign) 연동, 검색/등록/수정/삭제 로직 보완, 권한·소프트삭제 적용

## 작업 상세 내용
- [x] OpenFeign 연동
  - `HubClient` 인터페이스, `HubGetResponse` DTO 추가
  - `@EnableFeignClients` 활성화, `application.yml`에 `clients.hub.name/url` 설정 키 추가
  - `build.gradle` dependencies 블록 정리(auth 스타일)
- [x] 조회(단건/목록)
  - 단건: `getCompanyInfo`에서 허브 이름을 Feign으로 조회해 `CompanyResponseDto`에 채움
  - 목록: `searchCompany(name, hubId)` 구현
    - 이름/허브 필터(옵셔널) + 공백 → null 정규화
    - 요청당 `Map<UUID,String>` 캐시로 허브 N+1 최소화
    - 반환 DTO: `CompanyListResponseDto(List<CompanyResponseDto>)`
  - `CompanyRepository#search(name, hubId)` JPQL 추가(옵셔널 필터)
- [x] 등록
  - `createCompany`: `userId` 선택 입력 처리(null 허용)
- [x] 수정
  - 컨트롤러: 헤더 `X-User-Id`, `X-User-Role` 수신
  - 서비스: 권한 체크(역할 MASTER/HUB 또는 소유자 일치 시 허용)
  - 엔티티: `Company.updateInfo(...)` 도메인 메서드로 변경사항 반영(더티체킹; save 불필요)
- [x] 삭제
  - 컨트롤러: 헤더 `X-User-Id`, `X-User-Role` 수신
  - 서비스: 권한 체크(역할 ADMIN/HUB 또는 소유자 일치 시 허용)
  - 소프트삭제: `Timestamped.delete(UUID deletedBy)`로 `deletedAt/deletedBy` 설정
- [x] 예외 처리
  - `ForbiddenException` 추가, `GlobalExceptionHandler`에 403 매핑

## 기타 사항 (선택)
- 게이트웨이 연동 합의
  - 헤더: `X-User-Id`(UUID), `X-User-Role`(ADMIN|MASTER|HUB) 문자열 일치 필요
  - 허브 서비스명: `clients.hub.name`을 유레카 등록명과 일치시켜야 함(직접 URL 호출 시 `clients.hub.url` 사용)
- 추후 개선 제안
  - `@Cacheable`(Caffeine/Redis)로 hubId→hubName 캐시 도입
  - 목록 조회 `Pageable` 도입 및 정렬
  - 조회 쿼리에 `deletedAt IS NULL` 조건 반영(소프트삭제 숨김)
  - Resilience4j로 허브 호출 타임아웃/서킷브레이커 적용
  - API 스펙: GET /companies 응답은 `{ data: CompanyResponseDto[] }` 형식, 필드 `companyId, companyName, companyType, address, hubName(nullable)`
